### PR TITLE
Use config file for starting jupyter lap

### DIFF
--- a/app.py
+++ b/app.py
@@ -43,7 +43,7 @@ class JupyterLabWork(LightningWork):
 
         with open(jupyter_notebook_config_path, "a") as f:
             f.write(
-                """c.NotebookApp.tornado_settings = {'headers': {'Content-Security-Policy': "frame-ancestors * 'self' "}}"""  # noqa E501
+                f"{sys.executable} -m jupyter lab --ip {self.host} --port {self.port} --no-browser --config={jupyter_notebook_config_path}".split(" "),
             )
 
         with open(f"jupyter_lab_{self.port}", "w") as f:


### PR DESCRIPTION
The jupyter lab app is down, it doesn't start after doing `click&run`.

The issue is:
```[W 2022-07-15 14:23:44.142 ServerApp] Forbidden
[W 2022-07-15 14:23:44.143 ServerApp] 403 POST /api/security/csp-report (127.0.0.1) 0.53ms referer=http://127.0.0.1:7501/
[W 2022-07-15 14:24:05.568 ServerApp] Forbidden
[W 2022-07-15 14:24:05.569 ServerApp] 403 POST /api/security/csp-report (127.0.0.1) 1.41ms referer=http://127.0.0.1:7501/
[I 2022-07-15 14:24:16.778 ServerApp] Interrupted...```


This PR uses the config file to allow remote access.

TODO: submit a new version of the app @tchaton 