### PR TITLE
Retry 5 times if the page is not loaded (temporary fix)

### DIFF
--- a/tests/test_app_gallery.py
+++ b/tests/test_app_gallery.py
@@ -53,13 +53,14 @@ def get_gallery_app_page(app_name) -> Generator:
             [Config.id, Config.key, token],
         )
 
-        for retry_count in range(MAX_RETRY_COUNT):
+        for retry_count in range(5):
             try:
                 gallery_page.goto(f"{Config.url}/apps")
             except playwright._impl._api_types.TimeoutError as ex:
                 try_ex = ex
-            try_ex = None
-            break
+            else:
+                try_ex = None
+                break
         if try_ex:
             raise try_ex
 

--- a/tests/test_app_gallery.py
+++ b/tests/test_app_gallery.py
@@ -53,18 +53,15 @@ def get_gallery_app_page(app_name) -> Generator:
             [Config.id, Config.key, token],
         )
 
-        retry_count = 0
-        MAX_RETRY_COUNT = 5
-        while True:
+        for retry_count in range(MAX_RETRY_COUNT):
             try:
                 gallery_page.goto(f"{Config.url}/apps")
-            except playwright._impl._api_types.TimeoutError as e:
-                if retry_count >= MAX_RETRY_COUNT:
-                    raise e
-                retry_count += 1
-                continue
-            else:
-                break
+            except playwright._impl._api_types.TimeoutError as ex:
+                try_ex = ex
+            try_ex = None
+            break
+        if try_ex:
+            raise try_ex
 
         # Find the app in the gallery
         gallery_page.locator(f"text={app_name}").first.click()

--- a/tests/test_app_gallery.py
+++ b/tests/test_app_gallery.py
@@ -52,7 +52,19 @@ def get_gallery_app_page(app_name) -> Generator:
         """,
             [Config.id, Config.key, token],
         )
-        gallery_page.goto(f"{Config.url}/apps")
+
+        retry_count = 0
+        MAX_RETRY_COUNT = 5
+        while True:
+            try:
+                gallery_page.goto(f"{Config.url}/apps")
+            except playwright._impl._api_types.TimeoutError as e:
+                if retry_count >= MAX_RETRY_COUNT:
+                    raise e
+                retry_count += 1
+                continue
+            else:
+                break
 
         # Find the app in the gallery
         gallery_page.locator(f"text={app_name}").first.click()


### PR DESCRIPTION
## What does this PR do?

We have observed some flakyness on gallery e2e tests internally, with apps like InVideo, SpiderRan etc. Error message reads:

```python
playwright._impl._api_types.TimeoutError: Timeout 30000ms exceeded.
E       =========================== logs ===========================
E       navigating to "***/apps", waiting until "load"
E       ============================================================
```

The timeout of 30s exceeded for the link. Restarting the run though, fixes it. In this PR, I suggest a fix to retry loading the page if it times out (max_retry: 5 times)